### PR TITLE
Fix two issues for symbolic linking issues with Windows (EPERM: operation not permitted, scandir/symlink)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,19 @@
 # serverless-plugin-typescript
-[![serverless](http://public.serverless.com/badges/v3.svg)](http://www.serverless.com) [![npm version](https://badge.fury.io/js/serverless-plugin-typescript.svg)](https://badge.fury.io/js/serverless-plugin-typescript) [![Build Status](https://travis-ci.org/graphcool/serverless-plugin-typescript.svg?branch=master)](https://travis-ci.org/graphcool/serverless-plugin-typescript)
+[![serverless](http://public.serverless.com/badges/v3.svg)](http://www.serverless.com)
 
 Serverless plugin for zero-config Typescript support
+
+## HEWMEN Update
+Original NPM Module: npmjs.com/package/serverless-plugin-typescript
+
+This version of `serverless-typescript-plugin` fixes symbolic link issues with Windows OS resulting in the following errors:
+
+> 1) EPERM: operation not permitted, scandir...
+> 2) EPERM: operation not permitted, symlink...
+
+When attaching the "node_modules" folder to the build
+
+Created PR for original plugin: github.com/prismagraphql/serverless-plugin-typescript/pull/103
 
 ## Features
 
@@ -14,14 +26,18 @@ Serverless plugin for zero-config Typescript support
 ## Install
 
 ```sh
-yarn add --dev serverless-plugin-typescript
+yarn add --dev @hewmen/serverless-plugin-typescript
+```
+or
+```
+npm install --save-dev @hewmen/serverless-plugin-typescript
 ```
 
 Add the following plugin to your `serverless.yml`:
 
 ```yaml
 plugins:
-  - serverless-plugin-typescript
+  - '@hewmen/serverless-plugin-typescript'
 ```
 
 ## Configure
@@ -92,12 +108,12 @@ The normal Serverless deploy procedure will automatically compile with Typescrip
 The plugin integrates very well with [serverless-offline](https://github.com/dherault/serverless-offline) to
 simulate AWS Lambda and AWS API Gateway locally.
 
-Add the plugins to your `serverless.yml` file and make sure that `serverless-plugin-typescript`
+Add the plugins to your `serverless.yml` file and make sure that `@hewmen/serverless-plugin-typescript`
 precedes `serverless-offline` as the order is important:
 ```yaml
   plugins:
     ...
-    - serverless-plugin-typescript
+    - '@hewmen/serverless-plugin-typescript'
     ...
     - serverless-offline
     ...
@@ -113,7 +129,7 @@ Configure your service the same as mentioned above, but additionally add the `se
 plugin as follows:
 ```yaml
   plugins:
-    - serverless-plugin-typescript
+    - '@hewmen/serverless-plugin-typescript'
     - serverless-dynamodb-local
     - serverless-offline
 ```

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 Serverless plugin for zero-config Typescript support
 
 ## HEWMEN Update
-Original NPM Module: npmjs.com/package/serverless-plugin-typescript
+Original NPM Module: http://www.npmjs.com/package/serverless-plugin-typescript
 
 This version of `serverless-typescript-plugin` fixes symbolic link issues with Windows OS resulting in the following errors:
 
@@ -13,7 +13,7 @@ This version of `serverless-typescript-plugin` fixes symbolic link issues with W
 
 When attaching the "node_modules" folder to the build
 
-Created PR for original plugin: github.com/prismagraphql/serverless-plugin-typescript/pull/103
+Created PR for original plugin: http://www.github.com/prismagraphql/serverless-plugin-typescript/pull/103
 
 ## Features
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hewmen/serverless-plugin-typescript",
-  "version": "1.1.16",
+  "version": "1.1.17",
   "main": "dist/src/index.js",
   "files": [
     "dist",
@@ -17,7 +17,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/graphcool/serverless-plugin-typescript.git"
+    "url": "git+https://github.com/hewmen/serverless-plugin-typescript.git"
   },
   "keywords": [
     "serverless",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "serverless-plugin-typescript",
+  "name": "@hewmen/serverless-plugin-typescript",
   "version": "1.1.16",
   "main": "dist/src/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-plugin-typescript",
-  "version": "0.0.0-semantic-release",
+  "version": "1.1.16",
   "main": "dist/src/index.js",
   "files": [
     "dist",

--- a/src/index.ts
+++ b/src/index.ts
@@ -138,12 +138,12 @@ export class TypeScriptPlugin {
   async copyExtras() {
     // include node_modules into build
     if (!fs.existsSync(path.resolve(path.join(buildFolder, 'node_modules')))) {
-      fs.symlinkSync(path.resolve('node_modules'), path.resolve(path.join(buildFolder, 'node_modules')))
+      fs.symlinkSync(path.resolve('node_modules'), path.resolve(path.join(buildFolder, 'node_modules')), 'junction')
     }
 
     // include package.json into build so Serverless can exlcude devDeps during packaging
     if (!fs.existsSync(path.resolve(path.join(buildFolder, 'package.json')))) {
-      fs.symlinkSync(path.resolve('package.json'), path.resolve(path.join(buildFolder, 'package.json')))
+      fs.symlinkSync(path.resolve('package.json'), path.resolve(path.join(buildFolder, 'package.json')), 'file')
     }
 
     // include any "extras" from the "include" section


### PR DESCRIPTION
This solves 2 problems with Symbolic links on windows:

> EPERM: operation not permitted, scandir...
> EPERM: operation not permitted, symlink...

When linking the *.build/node_modules folders. This fix forces FS to create the link as a 'junction' instead of a sym-link. This fixes the folder not being created properly with latest windows updates as well as reduce restrictions requiring an elevated console in the UAC cases.

Also, even though this was the default in FS, we made sure to link the package.json as a 'file' to secure future updates and changes to the underlying FS or Windows behaviors making this non-functional.

Tested on Linux and Windows.