### PR TITLE
docs: Use commonjs module format

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The default `tsconfig.json` file used by the plugin looks like this:
     "target": "es5",
     "outDir": ".build",
     "moduleResolution": "node",
+    "module": "commonjs",
     "lib": ["es2015"],
     "rootDir": "./"
   }


### PR DESCRIPTION
Otherwise fails with:
```
  'export { hello };',
  '^^^^^^',
  '',
  'SyntaxError: Unexpected token export',
```
if it was set to `"module": "ESNext"`