### PR TITLE
Adding support for windows for symlink

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -138,12 +138,12 @@ export class TypeScriptPlugin {
   async copyExtras() {
     // include node_modules into build
     if (!fs.existsSync(path.resolve(path.join(buildFolder, 'node_modules')))) {
-      fs.symlinkSync(path.resolve('node_modules'), path.resolve(path.join(buildFolder, 'node_modules')))
+      fs.symlinkSync(path.resolve('node_modules'), path.resolve(path.join(buildFolder, 'node_modules')), 'dir')
     }
 
     // include package.json into build so Serverless can exlcude devDeps during packaging
     if (!fs.existsSync(path.resolve(path.join(buildFolder, 'package.json')))) {
-      fs.symlinkSync(path.resolve('package.json'), path.resolve(path.join(buildFolder, 'package.json')))
+      fs.symlinkSync(path.resolve('package.json'), path.resolve(path.join(buildFolder, 'package.json')), 'file')
     }
 
     // include any "extras" from the "include" section


### PR DESCRIPTION
Adding extra parameter to support windows with symlinkSync call.  This parameter has been documented as being ignored on other operating systems, but is required for windows