### PR TITLE
build: Typescript as peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,10 @@
   "dependencies": {
     "fs-extra": "^5.0.0",
     "globby": "^7.0.0",
-    "lodash": "^4.17.4",
-    "typescript": "^2.2.2"
+    "lodash": "^4.17.4"
+  },
+  "peerDependencies": {
+    "typescript": "^3.3.4000"
   },
   "jest": {
     "transform": {


### PR DESCRIPTION
Typescript is now a peerDependency in order to allow the usage of newer
Typescript versions.

BREAKING CHANGE: Typescript is now a peerDependency