### PR TITLE
Force noEmit compiler option to be false

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ The default `tsconfig.json` file used by the plugin looks like this:
 ```json
 {
   "compilerOptions": {
+    "noEmit": false,
     "preserveConstEnums": true,
     "strictNullChecks": true,
     "sourceMap": true,
@@ -47,7 +48,7 @@ The default `tsconfig.json` file used by the plugin looks like this:
 }
 ```
 
-> Note 1: The `outDir` and `rootDir` options cannot be overwritten.
+> Note 1: The `outDir`, `rootDir` and `noEmit` options cannot be overwritten.
 
 > Note 2: Don't confuse the [`tsconfig.json`](tsconfig.json) in this repository with the one mentioned above.
 

--- a/src/typescript.ts
+++ b/src/typescript.ts
@@ -6,6 +6,7 @@ import * as path from 'path'
 
 export function makeDefaultTypescriptConfig() {
   const defaultTypescriptConfig: ts.CompilerOptions = {
+    noEmit: false,
     preserveConstEnums: true,
     strictNullChecks: true,
     sourceMap: true,
@@ -120,11 +121,17 @@ export function getTypescriptConfig(
       logger.log(`Using local tsconfig.json`)
     }
 
-    // disallow overrriding rootDir
+    // disallow overriding rootDir
     if (configParseResult.options.rootDir && path.resolve(configParseResult.options.rootDir) !== path.resolve(cwd) && logger) {
-      logger.log('Warning: "rootDir" from local tsconfig.json is overriden')
+      logger.log('Warning: "rootDir" from local tsconfig.json is overridden')
     }
     configParseResult.options.rootDir = cwd
+
+    // disallow overriding noEmit
+    if (configParseResult.options.noEmit !== false) {
+      logger.log('Warning: "noEmit" from local tsconfig.json is overridden')
+    }
+    configParseResult.options.noEmit = false
 
     return configParseResult.options
   }


### PR DESCRIPTION
When a developer makes a mistake and has noEmit with a value of true in their tsconfig.json, this plugin errors out with "Typescript compilation failed" message.
The message is wrong, as compilation actually did succeed. The real problem is that there  simply were no files written to disk and as such there are no files for serverless to deploy.

To prevent developers from making this mistake, its value can be forced by the plugin.