### PR TITLE
fix: watch files callback missing correct this context

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -131,7 +131,7 @@ export class TypeScriptPlugin {
     this.serverless.cli.log(`Watching typescript files...`)
 
     this.isWatching = true
-    watchFiles(this.rootFileNames, this.originalServicePath, this.compileTs)
+    watchFiles(this.rootFileNames, this.originalServicePath, this.compileTs.bind(this))
   }
 
   async compileTs(): Promise<string[]> {


### PR DESCRIPTION
After the refactor, I broke this by removing the bind in the hooks. Adding the bind to the callback function retains the this context while keeping the modularity of the hooks property.

Fixes #162