### PR TITLE
Add option to disable the plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,22 @@ The default `tsconfig.json` file used by the plugin looks like this:
 
 All files from `package/include` will be included in the final build file. See [Exclude/Include](https://serverless.com/framework/docs/providers/aws/guide/packaging#exclude--include)
 
+### Disable the plugin
+
+
+You can disable plugin passing the following command line option to serverless:
+
+```yaml
+  --typescript-plugin [disabled|off|false]
+```
+
+Adding a typescriptPlugin section to the custom section of your serverless.yml to set default value if needed:
+
+```yaml
+custom:
+  typescriptPlugin:
+    enabled: false
+```
 
 ## Usage
 

--- a/src/Serverless.d.ts
+++ b/src/Serverless.d.ts
@@ -12,6 +12,11 @@ declare namespace Serverless {
       provider: {
         name: string
       }
+      custom: {
+        typescriptPlugin: {
+          enabled: boolean
+        }
+      }
       functions: {
         [key: string]: Serverless.Function
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,10 @@ export class TypeScriptPlugin {
   constructor(serverless: Serverless.Instance, options: Serverless.Options) {
     this.serverless = serverless
     this.options = options
+    
+    if (!this.isEnabled()) {
+      return;
+    }
 
     this.hooks = {
       'before:run:run': async () => {
@@ -93,7 +97,21 @@ export class TypeScriptPlugin {
       this.originalServicePath,
       this.serverless.service.provider.name,
       this.functions
-    )
+      )
+    }
+
+  isEnabled() {
+    const cliOption = this.options['typescript-plugin'];
+    if (cliOption === 'disabled' || cliOption === 'off' || cliOption === 'false') {
+      return false;
+    }
+
+    const custom = this.serverless.service.custom;
+    if (custom && custom.typescriptPlugin && (!custom.typescriptPlugin.enabled || custom.typescriptPlugin.enabled.toString() === 'false')) {
+        return false;
+    }
+
+    return true;
   }
 
   prepare() {


### PR DESCRIPTION
There is a way to disable the plugin.

> Error:

`Unhandled rejection Error: ENOENT: no such file or directory, symlink 'home/../node_modules' -> '/home/.build/node_modules'
`

> Use case:

We use plugin for serverless project. There are few different stacks and we use parametrized serverless to include what we need for every specific stack. Sometimes we only wrap cloudformation template within serverless and deploy it. That was a requirement.

> Description

_When we don't have functions (lambdas) within that stack and we have only wrapped cloudformation, plugin throws the following error:_
`Unhandled rejection Error: ENOENT: no such file or directory, symlink 'home/../node_modules' -> '/home/.build/node_modules'
`
That means that serverless don't create .build aidirectory because plugin can not exclude node_modules and than deploying and packaging fails.

> Solution:

Obviously, we need possibility to disable plugin at least in this situation. I added 2 ways to do that.

1.Adding a typescriptPlugin section to the custom section of your serverless.yml to set default value if needed:
```
custom:
  typescriptPlugin:
    enabled: false
```
2. Passing the following command line option to serverless command: 
`--typescript-plugin [disabled|off|false]`

The second option will override default value.